### PR TITLE
Update pol2reg.pl

### DIFF
--- a/pol2reg.pl
+++ b/pol2reg.pl
@@ -10,10 +10,10 @@ local $/;
 
 my $context;
 
-GetOptions ("context|=s" => \$context);
+GetOptions ("context|c=s" => \$context);
 
 sub usage {
-  print "Usage: $0 --context=HKLM|HKCU\n";
+  print "Usage: $0 --context HKLM|HKCU\n";
   exit 1;
 }
 


### PR DESCRIPTION
Corrected syntax error in GetOptions (typo missing the c alias for context).  Also corrected the documented syntax in the error message to user in the usage sub.